### PR TITLE
Allow multiple altNames

### DIFF
--- a/IceCertUtils/CertificateUtils.py
+++ b/IceCertUtils/CertificateUtils.py
@@ -249,7 +249,11 @@ class Certificate:
     def getAlternativeName(self):
         items = []
         for k, v in self.altName.items():
-            items.append("{0}:{1}".format(k, v))
+            if isinstance(v, str):
+                items.append("{0}:{1}".format(k, v))
+            else:
+                for v1 in v:
+                    items.append("{0}:{1}".format(k, v1))
         return ",".join(items) if len(items) > 0 else None
 
     def getExtendedKeyUsage(self):


### PR DESCRIPTION
This minor update allows to set multiple IP alternative names, that is useful for example to have IPv4 and IPv6 address in the certificate altNames