### PR TITLE
Remove default password

### DIFF
--- a/IceCertUtils/CertificateUtils.py
+++ b/IceCertUtils/CertificateUtils.py
@@ -3,7 +3,7 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-import sys, os, shutil, subprocess, tempfile, random, re, atexit, json
+import sys, os, shutil, subprocess, tempfile, re, atexit, json
 
 try:
     from subprocess import DEVNULL
@@ -201,7 +201,7 @@ class Certificate:
 
         # Write password to safe temporary file
         (f, passpath) = tempfile.mkstemp()
-        os.write(f, b(password or "password"))
+        os.write(f, b(password or ""))
         os.close(f)
 
         try:
@@ -366,7 +366,7 @@ class CertificateFactory:
         self.factories = {}
 
         # The password used to protect keys and key stores from the factory home directory
-        self.password = password or parent.password if parent else "password"
+        self.password = password or parent.password if parent else ""
         if parent:
             self.passpath = parent.passpath
         else:

--- a/IceCertUtils/IceCaUtil.py
+++ b/IceCertUtils/IceCaUtil.py
@@ -3,7 +3,7 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-import os, sys, getopt, tempfile, getpass, shutil, socket, uuid, IceCertUtils
+import os, sys, getopt, getpass, shutil, uuid, IceCertUtils
 
 def usage():
     print("usage: " + sys.argv[0] + " [--verbose --help --capass <pass>] init create list show export")

--- a/IceCertUtils/KeyToolCertificateUtils.py
+++ b/IceCertUtils/KeyToolCertificateUtils.py
@@ -3,7 +3,7 @@
 # Copyright (c) ZeroC, Inc. All rights reserved.
 #
 
-import os, subprocess, glob, tempfile
+import os, glob, tempfile
 
 from IceCertUtils.CertificateUtils import DistinguishedName, Certificate, CertificateFactory, b, d, read, opensslSupport, write
 

--- a/IceCertUtils/OpenSSLCertificateUtils.py
+++ b/IceCertUtils/OpenSSLCertificateUtils.py
@@ -71,7 +71,7 @@ class OpenSSLCertificate(Certificate):
 
         key = "-inkey={0}".format(self.key) if addkey else "-nokeys"
         try:
-            self.openSSL("pkcs12", out=path, inkey=self.key, certfile=chainfile, password=password or "password")
+            self.openSSL("pkcs12", out=path, inkey=self.key, certfile=chainfile, password=password or "")
         finally:
             if chainfile:
                 os.remove(chainfile)


### PR DESCRIPTION
This PR removes the default password, "password". Note that the keytool used to generate JKS certificate stores requires a password with at least 6 characters.